### PR TITLE
Reduce unnecessary job redundancy

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,6 @@
 name: pipeline
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test-job:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,9 @@
 name: pipeline
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   test-job:


### PR DESCRIPTION
@Immudzen, I'm terribly sorry.
The `on: [push, pull_request]` you copied from my `pipeline.yml` creates 2x more jobs than needed.

You can see screenshots of the problem/proof here: https://github.com/JuBiotech/murefi/pull/5

Quoting the docs:
"If multiple triggering events for your workflow occur at the same time,
multiple workflow runs will be triggered."